### PR TITLE
Fix bad code that seems to be contrary to the tips

### DIFF
--- a/hell/entries/32-button.md
+++ b/hell/entries/32-button.md
@@ -5,7 +5,7 @@ permalink: /{{ title | slug }}/index.html
 layout: layouts/entry.njk
 author: mmatuzo
 badcode: '<button display="flex" role="button">
-  <svg role="img" viewBox="0 0 13 13" aria-hidden="false" xmlns="http://www.w3.org/2000/svg" height="15px" width="15px" fill="#000" name="close">
+  <svg role="img" viewBox="0 0 13 13" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" height="15px" width="15px" fill="#000" name="close">
     <title>Close dialog</title>
     <path d="…">
     </path>


### PR DESCRIPTION
The issue list seems to suggest that using `aria-hidden="true"` is wrong, but the bad code actually used `aria-hidden="false"`. This pull request changes it to `aria-hidden="true"` in the badcode snippet.