### PR TITLE
Rewriting `6` without the footnotes.

### DIFF
--- a/hell/adventcalendar/2022/6.md
+++ b/hell/adventcalendar/2022/6.md
@@ -19,7 +19,7 @@ Most developers out there protect their websites against XSS by disallowing or c
 
 However, this article is **NOT** about XSS.
 
-This article is about an interesting attack that relies on HTML-only injections. The techniques here were [first described by Gareth Heyes in 2013](http://www.thespanner.co.uk/2013/05/16/dom-clobbering/) [1], the topic gained additional attention due to a recent research paper and its accompanying website [https://domclob.xyz/](https://domclob.xyz/) from Khodayari et al[2,3].
+This article is about an interesting attack that relies on HTML-only injections. The techniques here were [first described by Gareth Heyes in 2013](http://www.thespanner.co.uk/2013/05/16/dom-clobbering/), the topic gained additional attention due to a [recent research paper](https://publications.cispa.saarland/3756/) and its accompanying website [https://domclob.xyz/](https://domclob.xyz/) from Khodayari et al.
 
 ### Background
 
@@ -33,9 +33,9 @@ Have you ever noticed that whenever you include a HTML element with an `id` attr
 
 …will lead to `window.freddy` becoming a reference to that form element.
 
-This is a legacy inheritance from the very old days of HTML and also known as *[named property access](https://html.spec.whatwg.org/multipage/nav-history-apis.html#named-access-on-the-window-object)* in the HTML spec[4]. Studying the spec will inform us that the following elements will also appear on the `document` object: `embed`, `form`, `img`, and `object`.
+This is a legacy inheritance from the very old days of HTML and also known as *[named property access](https://html.spec.whatwg.org/multipage/nav-history-apis.html#named-access-on-the-window-object)* in the HTML spec. Studying the spec will inform us that the following elements will also appear on the `document` object: `embed`, `form`, `img`, and `object`.
 
-Given that web browsers have to maintain backwards compatibility support for relatively old web pages, *named property access* is designed in such a way [that element references come before lookups of APIs](https://webidl.spec.whatwg.org/#legacy-platform-object-abstract-ops) and other new attributes on the `window` and `document` object [5].
+Given that web browsers have to maintain backwards compatibility support for relatively old web pages, *named property access* is designed in such a way [that element references come before lookups of APIs](https://webidl.spec.whatwg.org/#legacy-platform-object-abstract-ops) and other new attributes on the `window` and `document` object.
 
 ### DOM Clobbering Attacks
 
@@ -91,16 +91,19 @@ How would your web page behave if seemingly innocent function calls like `docume
 
 The best way to prevent DOM Clobbering is to use a strong [Sanitizer](https://en.wikipedia.org/wiki/HTML_sanitization) library. A sanitizer typically goes through user-supplied HTML and only leaves the harmless bits - removing scripts, event handlers and other injections - like DOM Clobbering.
 
-The author of this article recommends [DOMPurify](https://github.com/cure53/DOMPurify/) [6]. By default, DOMPurify will remove all clobbering properties. Using the option `SANITIZE_NAMED_PROPS: true` will instead prefix user-supplied identifiers with `user-content-`.
+The author of this article recommends [DOMPurify](https://github.com/cure53/DOMPurify/). By default, DOMPurify will remove all clobbering properties. Using the option `SANITIZE_NAMED_PROPS: true` will instead prefix user-supplied identifiers with `user-content-`.
 
-However, if you want to live on the edge you might also want to look at the upcoming [Sanitizer API](https://wicg.github.io/sanitizer-api/) [7]. The specification for the Sanitizer API is still in development, but Chrome and Firefox are already shipping a prototype and the [Sanitizer API Playground](https://sanitizer-api.dev/) [8] has instructions on how to enable it.
+However, if you want to live on the edge you might also want to look at the upcoming [Sanitizer API](https://wicg.github.io/sanitizer-api/). The specification for the Sanitizer API is still in development, but Chrome and Firefox are already shipping a prototype and the [Sanitizer API Playground](https://sanitizer-api.dev/) has instructions on how to enable it.
 
 In order to fix DOM Clobbering with the Sanitizer API, you need to configure the Sanitizer to disallow attributes of type `name` and `id`:
 
 ```js
 const mySanitizer = new Sanitizer({
-  blockAttributes: {'id': '*', 'name': '*'}
-  });
+  blockAttributes: [
+    {'name': 'id', elements: '*'},
+    {'name': 'name', elements: '*'}
+  ]
+});
 someElement.setHTML(input, {sanitizer: mySanitizer});
 ```
 
@@ -108,11 +111,3 @@ Good luck!
 
 Sources:
 
-1. Gareth Heyes on DOM Clobbering in 2013: [http://www.thespanner.co.uk/2013/05/16/dom-clobbering/](http://www.thespanner.co.uk/2013/05/16/dom-clobbering/)
-2. Khodayari, Soheil and Pellegrino, Giancarlo (2023) [_It's (DOM) Clobbering Time: Attack Techniques, Prevalence, and Defenses._](https://publications.cispa.saarland/3756/). In: 44th IEEE Symposium on Security and Privacy. Conference: SP IEEE Symposium on Security and Privacy
-3. [https://domclob.xyz/](https://domclob.xyz/), also by Khodayari et al.
-4. [https://html.spec.whatwg.org/multipage/nav-history-apis.html#named-access-on-the-window-object](https://html.spec.whatwg.org/multipage/nav-history-apis.html#named-access-on-the-window-object)
-5. [https://webidl.spec.whatwg.org/#legacy-platform-object-abstract-ops](https://webidl.spec.whatwg.org/#legacy-platform-object-abstract-ops)
-6. [https://github.com/cure53/DOMPurify/](https://github.com/cure53/DOMPurify/)
-7. [https://wicg.github.io/sanitizer-api/](https://wicg.github.io/sanitizer-api/)
-8. [https://sanitizer-api.dev/](https://sanitizer-api.dev/)


### PR DESCRIPTION
- Move 2021 calendar
- Add separate calendar layout
- Update prism CSS to work with JS
- Add code label helper
- Add preview for first 3 posts
- Add noindex robot
- Fix author links
- Remove heading anchor links
- Remove tailwind reference
- Add bio
- Move all author links to author_links field
- Add post 4
- Add zebra styling to table rows
- Remove margin in ul lis
- Remove dark mode styling
- Add 5
- Update 2
- Update 1
- Add 6
- Remove zebra table styling
- Update 4
- Fix date
- Reduce font size of quotes
- Remove tabindex
- Change screenshot port
- Add 7
- Editorial and content changes to entry 6
- 6 without footnotes
