### PR TITLE
Fixed markup in datalist summary table

### DIFF
--- a/hell/adventcalendar/2022/11.md
+++ b/hell/adventcalendar/2022/11.md
@@ -550,8 +550,8 @@ The `<datalist>` approach is hands-down the best choice if you want to suggest p
 <ul>
 <li>compact</li>
 <li>user-supplied values are easy</li>
-<li>degrades to a standard `<input>`</li>
-<li>can fall back to `<input>`</li>
+<li>degrades to a standard <code>&lt;input&gt;</code></li>
+<li>can fall back to <code>&lt;input&gt;</code></li>
 </ul>
 </td>
 <td>


### PR DESCRIPTION
Without the change, an actual input element is placed in the final page where the text `<input>` is presumably intended.