### PR TITLE
add visible underline to linked code

### DIFF
--- a/hell/assets/style.css
+++ b/hell/assets/style.css
@@ -106,6 +106,14 @@ a:hover {
   text-decoration: none;
 }
 
+a code {
+  text-decoration: underline;
+}
+
+a:hover code {
+  text-decoration: none;
+}
+
 blockquote {
   font-size: 2.1rem;
 }


### PR DESCRIPTION
Noticed in an article that some of the code elements were linked because the cursor changed but they're missing a visual indication:
![Selection_2184](https://github.com/matuzo/HTMHell/assets/41970/a668de13-ecf0-4fee-aa78-0f6dac85f2f8)

this PR adds them:
![Selection_2183](https://github.com/matuzo/HTMHell/assets/41970/bd6b2fe6-fe44-42ab-b03b-af8def238be4)

