### PR TITLE
Prevent horizontal overflow caused by "languageless" code blocks

### DIFF
--- a/hell/assets/style.css
+++ b/hell/assets/style.css
@@ -167,6 +167,10 @@ code {
   font-size: 1.5rem;
 }
 
+code {
+  white-space: pre-wrap;
+}
+
 h2 code,
 h3 code {
   font-size: 0.8em;


### PR DESCRIPTION
Hi @matuzo,
I read the _HTMHell Advent Calendar 2023_ on my mobile and noticed that code samples that aren't marked with a language are not covered by Prism's styles.

When the line is long ([see here](https://www.htmhell.dev/adventcalendar/2023/12/)), it causes a horizontal overflow, so I thought I'd add this little `CSS` fix.

Thanks for the awesome content, and happy holidays!
